### PR TITLE
Remove spaces from keys in JSON output

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -1019,7 +1019,7 @@ def main():
                     if options.json:
                         data = dict()
                         for metric in metrics:
-                            data[metric['name']] = metric['value']
+                            data[metric['name'].replace(' ', '')] = metric['value']
                         print json.dumps(data)
                     else:
                         for metric in metrics:


### PR DESCRIPTION
JSON keys without spaces make the output a little easier to work with so you can use dot for each value.