### PR TITLE
changed psi caculation

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -828,15 +828,16 @@ def calculate_perceptual_speed_index(progress, directory):
     dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), directory)
     target_frame = os.path.join(dir, "ms_{0:06d}.png".format(progress[x - 1]["time"]))
     logging.debug("Target image for perSI is %s" % target_frame)
+    ssim = 0
     for p in progress:
         elapsed = p['time'] - last_ms
         # Full Path of the Current Frame
         current_frame = os.path.join(dir, "ms_{0:06d}.png".format(p["time"]))
         logging.debug("Current Image is %s" % current_frame)
         # Takes full path of PNG frames to compute SSIM value
-        ssim = compute_ssim(current_frame, target_frame)
         per_si += elapsed * (1.0 - ssim)
         last_ms = p['time']
+        ssim = compute_ssim(current_frame, target_frame)
     return int(per_si)
 
 


### PR DESCRIPTION
Changed the order of updating SSIM in PSI function. The first SSIM number should be zero before calculating the first PSI, then update the first SSIM to get the second PSI and so on. 