### PR TITLE
Configurable diff to decide when a frame is orange

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -643,7 +643,7 @@ def is_orange_frame(file, orange_file):
     out, err = compare.communicate()
     if re.match('^[0-9]+$', err):
       different_pixels = int(err)
-      if different_pixels < 100:
+      if different_pixels < options.orangelimitdiff:
         orange = True
 
   return orange
@@ -1280,6 +1280,8 @@ def main():
                       help="Calculate perceptual Speed Index")
   parser.add_argument('-j', '--json', action='store_true', default=False,
                       help="Set output format to JSON")
+  parser.add_argument('--orangelimitdiff', type=int, default=100,
+                    help="The limit when to the decice if the difference between frames makes a frame orange")
 
   options = parser.parse_args()
 


### PR DESCRIPTION
Using Chrome on Ubuntu and Mac OS X recording a video in 60fps using ffmpeg
it sometimes happens that the first frame after the full orange frame is
partly orange (half or 1/4 orange etc). This only happens for me with Chrome.
See #20. VisualMetrics then picks up that partly orange frame as the first
visual change.

The current default config only makes the difference between a full orange and
white. Making it configurable makes it possible to have a higher limit when you
run Chrome.

I got a bunch of example videos when this happens if need them Pat? It would be nicer to have a solution that fix the problem permanently but this at least makes it possible to have different configs  that avoids picking up a too early visual change on Chrome.