### PR TITLE
Continue to loop through the frames looking for gray/grey frames

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -574,7 +574,7 @@ def find_render_start(directory, gray_file):
                         logging.debug('Removing gray frame %s', files[i])
                         os.remove(files[i])
                     else:
-                        break
+                        continue
     except BaseException:
         logging.exception('Error getting render start')
 


### PR DESCRIPTION
In our use case we first has orange frames, then white, then gray and then site starts to render, so after removing the initial pre-render frame(s) we wanna continue to look for gray frames.

We still have the same problem as before with Chrome for orange but now with gray, we have frames that consists of both white and gray that aren't caught by VisualMetrics at the moment:
![ms_003184](https://cloud.githubusercontent.com/assets/540757/25991902/3aa05d34-3705-11e7-9096-28a1e35f80de.png)

They way I get around it before has been to check the frame before/after and check if they got the same diff.