### PR TITLE
Create temporary dir that is unique for color images.

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -1596,6 +1596,7 @@ def main():
                 "Use -h to see available options")
 
     temp_dir = tempfile.mkdtemp(prefix='vis-')
+    colors_temp_dir = tempfile.mkdtemp(prefix='vis-color-')
     directory = temp_dir
     if options.dir is not None:
         directory = options.dir
@@ -1636,21 +1637,21 @@ def main():
                     orange_file = os.path.join(os.path.dirname(
                         os.path.realpath(__file__)), 'orange.png')
                     if not os.path.isfile(orange_file):
-                        orange_file = os.path.join(temp_dir, 'orange.png')
+                        orange_file = os.path.join(colors_temp_dir, 'orange.png')
                         generate_orange_png(orange_file)
                 white_file = None
                 if options.white or options.startwhite or options.endwhite:
                     white_file = os.path.join(os.path.dirname(
                         os.path.realpath(__file__)), 'white.png')
                     if not os.path.isfile(white_file):
-                        white_file = os.path.join(temp_dir, 'white.png')
+                        white_file = os.path.join(colors_temp_dir, 'white.png')
                         generate_white_png(white_file)
                 gray_file = None
                 if options.gray:
                     gray_file = os.path.join(os.path.dirname(
                         os.path.realpath(__file__)), 'gray.png')
                     if not os.path.isfile(gray_file):
-                        gray_file = os.path.join(temp_dir, 'gray.png')
+                        gray_file = os.path.join(colors_temp_dir, 'gray.png')
                         generate_gray_png(gray_file)
                 video_to_frames(options.video, directory, options.force, orange_file,
                                 white_file, gray_file, options.multiple, options.viewport,


### PR DESCRIPTION
If you don't set a working dir for images from the cli, ffmpeg overwrites the created color images.

Running like this just works fine:
`./visualmetrics.py -i tests/data/lemons/video.mp4 --force --orange --startwhite -vvvv --dir mytmp`

But if you skip your own dir `./visualmetrics.py -i tests/data/lemons/video.mp4 --force --orange --startwhite -vvvv`  you get an error:

<pre>
09:04:20.353 - No video frames found in /private/var/folders/0v/qn5zr0w17n1c1svvr0ntbgxr0000gn/T/vis-7YHu1x
</pre>

The problem is that when the frames are extracted from the video, the color images are already created in the same dir and I think ffmpeg just removes everything in that current dir where it creates the frames.

There's a check that the file exists https://github.com/WPO-Foundation/visualmetrics/blob/master/visualmetrics.py#L795 but we don't log if something is wrong.