### PR TITLE
escape percent sign in sequence filename to comply with ffmpeg pattern

### DIFF
--- a/visualmetrics.py
+++ b/visualmetrics.py
@@ -125,9 +125,12 @@ def extract_frames(video, directory, full_resolution, viewport):
             options.thumbsize)
         if full_resolution:
             scale = ''
+        # escape directory name 
+        # see https://en.wikibooks.org/wiki/FFMPEG_An_Intermediate_Guide/image_sequence#Percent_in_filename
+        dir_escaped = directory.replace("%", "%%")
         command = ['ffmpeg', '-v', 'debug', '-i', video, '-vsync', '0',
                    '-vf', crop + scale + decimate + '=0:64:640:0.001',
-                   os.path.join(directory, 'img-%d.png')]
+                   os.path.join(dir_escaped, 'img-%d.png')]
         logging.debug(' '.join(command))
         lines = []
         proc = subprocess.Popen(command, stderr=subprocess.PIPE)


### PR DESCRIPTION
According to the ffmpeg doc, we need to escape any percent sign in the directory path. So, it will not try to pattern match on the directory name (if there's a % in there..).

see https://en.wikibooks.org/wiki/FFMPEG_An_Intermediate_Guide/image_sequence#Percent_in_filename